### PR TITLE
Migrate to Gatsby V2

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,41 +1,41 @@
-const Promise = require("bluebird")
-const axios = require(`axios`)
-const crypto = require(`crypto`)
+const Promise = require('bluebird');
+const axios = require('axios');
+const crypto = require('crypto');
 
-exports.sourceNodes = ({ boundActionCreators }, { appId, collections, perPage = 10 }) => {
-    const { createNode } = boundActionCreators
-
-    return Promise.all(collections.map(collection => {
-        return axios.get(`https://api.unsplash.com/collections/${collection}/photos`, {
-            params: {
-                client_id: appId,
-                per_page: perPage
-            }
-        }).then(res => {
-            res.data.map(photo => {
-                const digest = crypto
-                    .createHash(`md5`)
-                    .update(JSON.stringify(photo))
-                    .digest(`hex`)
-
-                const node = Object.assign(
-                    photo,
-                    {
-                      parent: `__SOURCE__`,
-                      children: [],
-                      internal: {
-                        type: `UnsplashPhoto`,
-                        contentDigest: digest,
-                        mediaType: `application/json`
-                      },
-                    }
-                )
-
-                createNode(node)
-                return true;
-            })
+exports.sourceNodes = ({ actions }, { appId, collections, perPage = 10 }) => {
+  const { createNode } = actions;
+  return Promise.all(
+    collections.map(collection => {
+      return axios
+        .get(`https://api.unsplash.com/collections/${collection}/photos`, {
+          params: {
+            client_id: appId,
+            per_page: perPage
+          }
         })
-    })).catch(error => {
-        console.log(error);
-    });
-}
+        .then(res => {
+          res.data.map(photo => {
+            const digest = crypto
+              .createHash('md5')
+              .update(JSON.stringify(photo))
+              .digest('hex');
+
+            const node = Object.assign(photo, {
+              parent: '__SOURCE__',
+              children: [],
+              internal: {
+                type: 'UnsplashPhoto',
+                contentDigest: digest,
+                mediaType: 'application/json'
+              }
+            });
+
+            createNode(node);
+            return true;
+          });
+        });
+    })
+  ).catch(error => {
+    console.log(error);
+  });
+};

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -36,6 +36,6 @@ exports.sourceNodes = ({ actions }, { appId, collections, perPage = 10 }) => {
         });
     })
   ).catch(error => {
-    console.log(error);
+    console.error(error);
   });
 };


### PR DESCRIPTION
Hi @vacas5 👋Thanks for creating an awesome plugin. I was playing around with it this morning and noticed there was a warning being output in the console (when used locally, you don't see it if you install from npm):

> `boundActionCreators` is deprecated. Please use `actions` instead. For migration instructions, see https://gatsby.dev/boundActionCreators

I've updated `boundActionCreators` as per the instructions in the [Gatsby docs](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions). 

I've also swapped the `console.log` with `console.error` and made quotes consistent. Hope you find this PR useful!